### PR TITLE
refactor!: Re-impl all macro to derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utility-types"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["duskmoon (Campbell He) <kp.campbell.he@duskmoon314.com>"]
 license = "MIT"
@@ -14,9 +14,10 @@ description = "This crate use proc-macro to realize several utility types of Typ
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+darling = "0.20.9"
+proc-macro2 = "1.0.85"
+quote = "1.0.36"
+syn = { version = "2.0.66", features = ["full"] }
 
 [dev-dependencies]
-trybuild = { version = "1.0", features = ["diff"] }
+trybuild = { version = "1.0.96", features = ["diff"] }

--- a/README.md
+++ b/README.md
@@ -1,45 +1,64 @@
 # utility types
 
-**WIP**
+This crate use proc-macro to realize several utility types of Typescript in Rust.
 
-This crate use proc-macro to realize several utility types of TypeScript
+| macro     | Typescript Utility Type                                                                                                                   |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [Partial] | [Partial\<Type\>](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype)                                            |
+| [Pick]    | [Pick\<Type, Keys\>](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)                                       |
+| [Omit]    | [Omit\<Type, Keys\>](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)                                       |
+| [Extract] | [Extract\<Type, Union\>](https://www.typescriptlang.org/docs/handbook/utility-types.html#extracttype-union)                               |
+| [Exclude] | [Exclude\<UnionType, ExcludedMembers\>](https://www.typescriptlang.org/docs/handbook/utility-types.html#excludeuniontype-excludedmembers) |
 
 ## Example
 
-source code:
+Here is an example of how to use this crate.
 
 ```rust
-#[partial(PartialArticle)]
-#[pick(ContentComments, [content, comments], [Debug])]
-#[omit(AuthorLikedComments, [content], [])]
-pub struct Article<T> {
-    author: String,
-    content: String,
-    liked: usize,
-    comments: T,
+use utility_types::{Omit, Partial, Pick, Required};
+#[derive(Clone, Partial, Required, Pick, Omit)]
+#[partial(ident = PartialFoo, derive(Debug, PartialEq))]
+#[required(ident = RequiredFoo, derive(Debug, PartialEq))]
+#[pick(arg(ident = PickAB, fields(a, b), derive(Debug, PartialEq)))]
+#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq)))]
+pub struct Foo {
+    a: u8,
+    b: Option<u8>,
+    c: Option<Vec<u8>>,
 }
 ```
 
-generated code:
+The above code will generate the following code.
 
 ```rust
-pub struct Article<T> {
-    author: String,
-    content: String,
-    liked: usize,
-    comments: T,
+#[derive(Debug, PartialEq)]
+pub struct PartialFoo {
+    a: Option<u8>,
+    b: Option<Option<u8>>,
+    c: Option<Option<Vec<u8>>>,
 }
-pub struct AuthorLikedComments<T> {
-    author: String,
-    liked: usize,
-    comments: T,
+#[derive(Debug, PartialEq)]
+pub struct RequiredFoo {
+    a: u8,
+    b: u8,
+    c: Vec<u8>,
 }
-#[derive(Debug)]
-pub struct ContentComments<T> {
-    content: String,
-    comments: T,
+#[derive(Debug, PartialEq)]
+pub struct PickAB {
+    a: u8,
+    b: Option<u8>,
+}
+#[derive(Debug, PartialEq)]
+pub struct OmitCD {
+    a: u8,
+    b: Option<u8>,
 }
 ```
+
+Some useful traits are also generated:
+
+- `From<Foo>` for `PartialFoo`, `PickAB`, `OmitCD`
+- `From<PartialFoo>` for `Foo`
 
 ## Known Issue
 

--- a/src/exclude.rs
+++ b/src/exclude.rs
@@ -1,0 +1,169 @@
+use std::ops::Deref;
+
+use darling::ast::{Data, Fields, Style};
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromMeta, FromVariant};
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Attribute, Field, Generics, Ident, Visibility};
+
+use crate::utils::IdentList;
+
+#[derive(Debug, FromMeta)]
+struct ExcludeArgs {
+    ident: Ident,
+
+    variants: IdentList,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug)]
+struct ExcludeArgsList(Vec<ExcludeArgs>);
+
+impl Deref for ExcludeArgsList {
+    type Target = Vec<ExcludeArgs>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromMeta for ExcludeArgsList {
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let values = items
+            .iter()
+            .map(|item| match item {
+                darling::ast::NestedMeta::Meta(meta) => ExcludeArgs::from_meta(meta),
+                _ => Err(darling::Error::unexpected_type("non meta").with_span(item)),
+            })
+            .collect::<darling::Result<Vec<ExcludeArgs>>>()?;
+
+        Ok(Self(values))
+    }
+}
+
+#[derive(Debug, FromVariant)]
+#[darling(attributes(exclude), forward_attrs(allow, doc, cfg))]
+struct ExcludeVariant {
+    ident: Ident,
+
+    discriminant: Option<syn::Expr>,
+
+    fields: Fields<Field>,
+
+    attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(exclude),
+    forward_attrs(allow, doc, cfg),
+    supports(enum_any)
+)]
+struct ExcludeInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<ExcludeVariant, Ignored>,
+
+    #[darling(flatten)]
+    args: ExcludeArgsList,
+}
+
+pub fn exclude(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match ExcludeInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let vis = input.vis;
+    let ident = input.ident;
+    let generics = input.generics;
+    let variants = input.data.take_enum().unwrap();
+
+    let excludes = input.args.iter().map(|arg| {
+        let derive_attr = match &arg.derive {
+            Some(derives) => {
+                let derives = derives.iter();
+                quote! {
+                    #[derive(#(#derives),*)]
+                }
+            }
+            None => quote! {},
+        };
+
+        let exclude_ident = &arg.ident;
+
+        let mut variant_idents = Vec::new();
+        let mut variant_declares = Vec::new();
+        let mut variant_from_exclude = Vec::new();
+
+        variants.iter().for_each(|variant| {
+            let variant_ident = &variant.ident;
+
+            // Check if ident is in the list of variants to Exclude
+            if arg.variants.contains(variant_ident) {
+                return;
+            }
+
+            let attrs = &variant.attrs;
+            let fields = &variant.fields;
+            let discriminant = &variant.discriminant;
+
+            variant_idents.push(variant_ident);
+            variant_declares.push(quote! {
+                #(#attrs)*
+                #variant_ident #fields #discriminant
+            });
+            variant_from_exclude.push(match fields.style {
+                Style::Unit => quote! {
+                    #exclude_ident::#variant_ident => #ident::#variant_ident
+                },
+                Style::Tuple => {
+                    let field_idents = (0..fields.len()).map(|i| format_ident!("F{i}")).collect::<Vec<_>>();
+
+                    quote! {
+                        #exclude_ident::#variant_ident(#(#field_idents),*) => #ident::#variant_ident(#(#field_idents),*)
+                    }
+                }
+                Style::Struct => {
+                    let field_idents = fields.iter().map(|field| field.ident.as_ref().unwrap()).collect::<Vec<_>>();
+
+                    quote! {
+                        #exclude_ident::#variant_ident { #(#field_idents),* } => #ident::#variant_ident { #(#field_idents),* }
+                    }
+                }
+            })
+        });
+
+        // TODO: Generics may not be needed in the generated struct
+        // It may be better to check all fields for generics
+        quote! {
+            #derive_attr
+            #vis enum #exclude_ident #generics {
+                #(#variant_declares),*
+            }
+
+            impl #generics core::convert::From<#exclude_ident #generics> for #ident #generics {
+                fn from(src: #exclude_ident #generics) -> Self {
+                    match src {
+                        #(#variant_from_exclude),*
+                    }
+                }
+            }
+        }
+    });
+
+    quote! {
+        #(#excludes)*
+    }
+    .into()
+}

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,0 +1,169 @@
+use std::ops::Deref;
+
+use darling::ast::{Data, Fields, Style};
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromMeta, FromVariant};
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Attribute, Field, Generics, Ident, Visibility};
+
+use crate::utils::IdentList;
+
+#[derive(Debug, FromMeta)]
+struct ExtractArgs {
+    ident: Ident,
+
+    variants: IdentList,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug)]
+struct ExtractArgsList(Vec<ExtractArgs>);
+
+impl Deref for ExtractArgsList {
+    type Target = Vec<ExtractArgs>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromMeta for ExtractArgsList {
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let values = items
+            .iter()
+            .map(|item| match item {
+                darling::ast::NestedMeta::Meta(meta) => ExtractArgs::from_meta(meta),
+                _ => Err(darling::Error::unexpected_type("non meta").with_span(item)),
+            })
+            .collect::<darling::Result<Vec<ExtractArgs>>>()?;
+
+        Ok(Self(values))
+    }
+}
+
+#[derive(Debug, FromVariant)]
+#[darling(attributes(extract), forward_attrs(allow, doc, cfg))]
+struct ExtractVariant {
+    ident: Ident,
+
+    discriminant: Option<syn::Expr>,
+
+    fields: Fields<Field>,
+
+    attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(extract),
+    forward_attrs(allow, doc, cfg),
+    supports(enum_any)
+)]
+struct ExtractInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<ExtractVariant, Ignored>,
+
+    #[darling(flatten)]
+    args: ExtractArgsList,
+}
+
+pub fn extract(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match ExtractInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let vis = input.vis;
+    let ident = input.ident;
+    let generics = input.generics;
+    let variants = input.data.take_enum().unwrap();
+
+    let extracts = input.args.iter().map(|arg| {
+        let derive_attr = match &arg.derive {
+            Some(derives) => {
+                let derives = derives.iter();
+                quote! {
+                    #[derive(#(#derives),*)]
+                }
+            }
+            None => quote! {},
+        };
+
+        let extract_ident = &arg.ident;
+
+        let mut variant_idents = Vec::new();
+        let mut variant_declares = Vec::new();
+        let mut variant_from_extract = Vec::new();
+
+        variants.iter().for_each(|variant| {
+            let variant_ident = &variant.ident;
+
+            // Check if ident is in the list of variants to extract
+            if !arg.variants.contains(variant_ident) {
+                return;
+            }
+
+            let attrs = &variant.attrs;
+            let fields = &variant.fields;
+            let discriminant = &variant.discriminant;
+
+            variant_idents.push(variant_ident);
+            variant_declares.push(quote! {
+                #(#attrs)*
+                #variant_ident #fields #discriminant
+            });
+            variant_from_extract.push(match fields.style {
+                Style::Unit => quote! {
+                    #extract_ident::#variant_ident => #ident::#variant_ident
+                },
+                Style::Tuple => {
+                    let field_idents = (0..fields.len()).map(|i| format_ident!("F{i}")).collect::<Vec<_>>();
+
+                    quote! {
+                        #extract_ident::#variant_ident(#(#field_idents),*) => #ident::#variant_ident(#(#field_idents),*)
+                    }
+                }
+                Style::Struct => {
+                    let field_idents = fields.iter().map(|field| field.ident.as_ref().unwrap()).collect::<Vec<_>>();
+
+                    quote! {
+                        #extract_ident::#variant_ident { #(#field_idents),* } => #ident::#variant_ident { #(#field_idents),* }
+                    }
+                }
+            })
+        });
+
+        // TODO: Generics may not be needed in the generated struct
+        // It may be better to check all fields for generics
+        quote! {
+            #derive_attr
+            #vis enum #extract_ident #generics {
+                #(#variant_declares),*
+            }
+
+            impl #generics core::convert::From<#extract_ident #generics> for #ident #generics {
+                fn from(src: #extract_ident #generics) -> Self {
+                    match src {
+                        #(#variant_from_extract),*
+                    }
+                }
+            }
+        }
+    });
+
+    quote! {
+        #(#extracts)*
+    }
+    .into()
+}

--- a/src/omit.rs
+++ b/src/omit.rs
@@ -1,0 +1,149 @@
+use std::ops::Deref;
+
+use darling::ast::Data;
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromField, FromMeta};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Attribute, Generics, Ident, Type, Visibility};
+
+use crate::utils::IdentList;
+
+#[derive(Debug, FromMeta)]
+struct OmitArgs {
+    ident: Ident,
+
+    fields: IdentList,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug)]
+struct OmitArgsList(Vec<OmitArgs>);
+
+impl Deref for OmitArgsList {
+    type Target = Vec<OmitArgs>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromMeta for OmitArgsList {
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let values = items
+            .iter()
+            .map(|item| match item {
+                darling::ast::NestedMeta::Meta(meta) => OmitArgs::from_meta(meta),
+                _ => Err(darling::Error::unexpected_type("non meta").with_span(item)),
+            })
+            .collect::<darling::Result<Vec<OmitArgs>>>()?;
+
+        Ok(Self(values))
+    }
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(omit), forward_attrs(allow, doc, cfg))]
+struct OmitField {
+    ident: Option<Ident>,
+
+    vis: Visibility,
+
+    ty: Type,
+
+    attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(omit),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_named)
+)]
+struct OmitInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<Ignored, OmitField>,
+
+    #[darling(flatten)]
+    args: OmitArgsList,
+}
+
+pub fn omit(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match OmitInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let vis = input.vis;
+    let ident = input.ident;
+    let generics = input.generics;
+    let fields = input.data.take_struct().unwrap();
+
+    let omits = input.args.iter().map(|arg| {
+        let derive_attr = match &arg.derive {
+            Some(derives) => {
+                let derives = derives.iter();
+                quote! {
+                    #[derive(#(#derives),*)]
+                }
+            }
+            None => quote! {},
+        };
+
+        let omit_ident = &arg.ident;
+
+        let mut field_idents = Vec::new();
+        let mut field_declares = Vec::new();
+
+        fields.fields.iter().for_each(|field| {
+            let ident = field.ident.as_ref().unwrap();
+
+            // Check if ident is in the list of fields to Omit
+            if arg.fields.contains(ident) {
+                return;
+            }
+
+            let attrs = &field.attrs;
+            let vis = &field.vis;
+            let ty = &field.ty;
+
+            field_idents.push(ident);
+            field_declares.push(quote! {
+                #(#attrs)*
+                #vis #ident: #ty,
+            });
+        });
+
+        // TODO: Generics may not be needed in the generated struct
+        // It may be better to check all fields for generics
+        quote! {
+            #derive_attr
+            #vis struct #omit_ident #generics {
+                #(#field_declares)*
+            }
+
+            impl #generics From<#ident #generics> for #omit_ident #generics {
+                fn from(src: #ident #generics) -> Self {
+                    Self {
+                        #(#field_idents: src.#field_idents),*
+                    }
+                }
+            }
+        }
+    });
+
+    quote! {
+        #(#omits)*
+    }
+    .into()
+}

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,0 +1,124 @@
+use darling::ast::Data;
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromField, FromMeta};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Attribute, Generics, Ident, Type, Visibility};
+
+#[derive(Debug, FromMeta)]
+struct PartialArgs {
+    ident: Ident,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(partial), forward_attrs(allow, doc, cfg))]
+struct PartialField {
+    ident: Option<Ident>,
+
+    vis: Visibility,
+
+    ty: Type,
+
+    attrs: Vec<Attribute>,
+
+    default: Option<syn::Expr>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(partial),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_named, struct_tuple)
+)]
+struct PartialInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<Ignored, PartialField>,
+
+    #[darling(flatten)]
+    args: PartialArgs,
+}
+
+pub fn partial(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match PartialInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let derive_attr = match input.args.derive {
+        Some(derives) => {
+            let derives = derives.iter();
+            quote! {
+                #[derive(#(#derives),*)]
+            }
+        }
+        None => quote! {},
+    };
+    let vis = input.vis;
+    let ident = input.ident;
+    let partial_ident = input.args.ident;
+    let generics = input.generics;
+    let fields = input.data.take_struct().unwrap();
+
+    let mut field_idents = Vec::new();
+    let mut field_declares = Vec::new();
+    let mut field_from_partial = Vec::new();
+
+    fields.fields.iter().for_each(|field| {
+        let vis = &field.vis;
+        let ident = field.ident.as_ref().unwrap();
+        let attrs = &field.attrs;
+
+        let ty = &field.ty;
+        // TODO: It may be better to keep the original type if it is already an Option
+        let ty = quote! { Option<#ty> };
+
+        field_idents.push(ident.clone());
+        field_declares.push(quote! {
+            #(#attrs)*
+            #vis #ident: #ty
+        });
+        field_from_partial.push(match &field.default {
+            Some(default) => quote! {
+                #ident: src.#ident.unwrap_or(#default)
+            },
+            None => quote! {
+                #ident: src.#ident.unwrap_or_default()
+            },
+        });
+    });
+
+    quote! {
+        #derive_attr
+        #vis struct #partial_ident #generics {
+            #(#field_declares),*
+        }
+
+        impl #generics core::convert::From<#ident #generics> for #partial_ident #generics {
+            fn from(src: #ident #generics) -> Self {
+                Self {
+                    #(#field_idents: Some(src.#field_idents)),*
+                }
+            }
+        }
+
+        impl #generics core::convert::From<#partial_ident #generics> for #ident #generics {
+            fn from(src: #partial_ident #generics) -> Self {
+                Self {
+                    #(#field_from_partial),*
+                }
+            }
+        }
+    }
+    .into()
+}

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -1,0 +1,149 @@
+use std::ops::Deref;
+
+use darling::ast::Data;
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromField, FromMeta};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Attribute, Generics, Ident, Type, Visibility};
+
+use crate::utils::IdentList;
+
+#[derive(Debug, FromMeta)]
+struct PickArgs {
+    ident: Ident,
+
+    fields: IdentList,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug)]
+struct PickArgsList(Vec<PickArgs>);
+
+impl Deref for PickArgsList {
+    type Target = Vec<PickArgs>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromMeta for PickArgsList {
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let values = items
+            .iter()
+            .map(|item| match item {
+                darling::ast::NestedMeta::Meta(meta) => PickArgs::from_meta(meta),
+                _ => Err(darling::Error::unexpected_type("non meta").with_span(item)),
+            })
+            .collect::<darling::Result<Vec<PickArgs>>>()?;
+
+        Ok(Self(values))
+    }
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(pick), forward_attrs(allow, doc, cfg))]
+struct PickField {
+    ident: Option<Ident>,
+
+    vis: Visibility,
+
+    ty: Type,
+
+    attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(pick),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_named)
+)]
+struct PickInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<Ignored, PickField>,
+
+    #[darling(flatten)]
+    args: PickArgsList,
+}
+
+pub fn pick(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match PickInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let vis = input.vis;
+    let ident = input.ident;
+    let generics = input.generics;
+    let fields = input.data.take_struct().unwrap();
+
+    let picks = input.args.iter().map(|arg| {
+        let derive_attr = match &arg.derive {
+            Some(derives) => {
+                let derives = derives.iter();
+                quote! {
+                    #[derive(#(#derives),*)]
+                }
+            }
+            None => quote! {},
+        };
+
+        let pick_ident = &arg.ident;
+
+        let mut field_idents = Vec::new();
+        let mut field_declares = Vec::new();
+
+        fields.fields.iter().for_each(|field| {
+            let ident = field.ident.as_ref().unwrap();
+
+            // Check if ident is in the list of fields to pick
+            if !arg.fields.contains(ident) {
+                return;
+            }
+
+            let attrs = &field.attrs;
+            let vis = &field.vis;
+            let ty = &field.ty;
+
+            field_idents.push(ident);
+            field_declares.push(quote! {
+                #(#attrs)*
+                #vis #ident: #ty,
+            });
+        });
+
+        // TODO: Generics may not be needed in the generated struct
+        // It may be better to check all fields for generics
+        quote! {
+            #derive_attr
+            #vis struct #pick_ident #generics {
+                #(#field_declares)*
+            }
+
+            impl #generics From<#ident #generics> for #pick_ident #generics {
+                fn from(src: #ident #generics) -> Self {
+                    Self {
+                        #(#field_idents: src.#field_idents),*
+                    }
+                }
+            }
+        }
+    });
+
+    quote! {
+        #(#picks)*
+    }
+    .into()
+}

--- a/src/required.rs
+++ b/src/required.rs
@@ -1,0 +1,129 @@
+use darling::ast::Data;
+use darling::util::{Ignored, PathList};
+use darling::{FromDeriveInput, FromField, FromMeta};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    AngleBracketedGenericArguments, Attribute, GenericArgument, Generics, Ident, PathArguments,
+    Type, TypePath, Visibility,
+};
+
+#[derive(Debug, FromMeta)]
+struct RequiredArgs {
+    ident: Ident,
+
+    derive: Option<PathList>,
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(required), forward_attrs(allow, doc, cfg))]
+struct RequiredField {
+    ident: Option<Ident>,
+
+    vis: Visibility,
+
+    ty: Type,
+
+    attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(
+    attributes(required),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_named, struct_tuple)
+)]
+struct RequiredInput {
+    ident: Ident,
+
+    vis: Visibility,
+
+    generics: Generics,
+
+    data: Data<Ignored, RequiredField>,
+
+    #[darling(flatten)]
+    args: RequiredArgs,
+}
+
+pub fn required(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let input = match RequiredInput::from_derive_input(&input) {
+        Ok(input) => input,
+        Err(err) => {
+            return TokenStream::from(err.write_errors());
+        }
+    };
+
+    let derive_attr = match input.args.derive {
+        Some(derives) => {
+            let derives = derives.iter();
+            quote! {
+                #[derive(#(#derives),*)]
+            }
+        }
+        None => quote! {},
+    };
+    let vis = input.vis;
+    let _ident = input.ident;
+    let required_ident = input.args.ident;
+    let generics = input.generics;
+    let fields = input.data.take_struct().unwrap();
+
+    let mut field_idents = Vec::new();
+    let mut field_declares = Vec::new();
+
+    fields.fields.iter().for_each(|field| {
+        let vis = &field.vis;
+        let ident = field.ident.as_ref().unwrap();
+        let attrs = &field.attrs;
+        let ty = &field.ty;
+
+        // Check if the field is optional
+        let ty = match ty {
+            Type::Path(TypePath { path, .. }) => {
+                let segments_str = &path
+                    .segments
+                    .iter()
+                    .map(|segment| segment.ident.to_string())
+                    .collect::<Vec<_>>()
+                    .join("::");
+                let option_segment = ["Option", "std::option::Option", "core::option::Option"]
+                    .iter()
+                    .find(|s| segments_str == *s)
+                    .and_then(|_| path.segments.last());
+                let inner_type = option_segment
+                    .and_then(|path_seg| match &path_seg.arguments {
+                        PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                            args,
+                            ..
+                        }) => args.first(),
+                        _ => None,
+                    })
+                    .and_then(|generic_arg| match generic_arg {
+                        GenericArgument::Type(ty) => Some(ty),
+                        _ => None,
+                    });
+
+                inner_type.unwrap_or(ty)
+            }
+            _ => ty,
+        };
+
+        field_idents.push(ident.clone());
+        field_declares.push(quote! {
+            #(#attrs)*
+            #vis #ident: #ty
+        });
+    });
+
+    // TODO: Implement From<RequiredStruct> for OriginalStruct
+    quote! {
+        #derive_attr
+        #vis struct #required_ident #generics {
+            #(#field_declares),*
+        }
+    }
+    .into()
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,50 @@
+use std::ops::Deref;
+
+use darling::FromMeta;
+use syn::{Ident, Meta};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct IdentList(Vec<Ident>);
+
+impl IdentList {
+    pub fn new<T: Into<Ident>>(values: Vec<T>) -> Self {
+        Self(values.into_iter().map(T::into).collect())
+    }
+}
+
+impl Deref for IdentList {
+    type Target = Vec<Ident>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<Ident>> for IdentList {
+    fn from(values: Vec<Ident>) -> Self {
+        Self(values)
+    }
+}
+
+impl FromMeta for IdentList {
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let values = items
+            .iter()
+            .map(|item| match item {
+                darling::ast::NestedMeta::Meta(Meta::Path(path)) => match path.get_ident() {
+                    Some(ident) => Ok(ident.clone()),
+                    None => Err(darling::Error::unexpected_type("non ident").with_span(item)),
+                },
+                _ => {
+                    Err(darling::Error::unexpected_type("non path, expected ident").with_span(item))
+                }
+            })
+            .collect::<darling::Result<Vec<Ident>>>()?;
+
+        if values.is_empty() {
+            return Err(darling::Error::too_few_items(1));
+        }
+
+        Ok(Self::new(values))
+    }
+}

--- a/tests/exclude.rs
+++ b/tests/exclude.rs
@@ -1,0 +1,15 @@
+use trybuild::TestCases;
+
+#[test]
+fn exclude() {
+    let t = TestCases::new();
+
+    t.pass("tests/exclude/01-ident.rs");
+    t.pass("tests/exclude/02-zero-arg.rs");
+    t.pass("tests/exclude/03-multi-args.rs");
+    t.compile_fail("tests/exclude/04-no-ident.rs");
+    t.compile_fail("tests/exclude/05-empty-ident.rs");
+    t.compile_fail("tests/exclude/06-no-variants.rs");
+    t.compile_fail("tests/exclude/07-empty-variants.rs");
+    t.pass("tests/exclude/08-variant-not-exist.rs");
+}

--- a/tests/exclude/01-ident.rs
+++ b/tests/exclude/01-ident.rs
@@ -1,0 +1,22 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(ident = Terrestrial, variants(Jupiter, Saturn, Uranus, Neptune), derive(Debug, PartialEq, Clone, Copy)))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {
+    let terrestrial = Terrestrial::Earth;
+
+    let planet: Planet = terrestrial.into();
+
+    assert_eq!(planet, Planet::Earth);
+}

--- a/tests/exclude/02-zero-arg.rs
+++ b/tests/exclude/02-zero-arg.rs
@@ -1,0 +1,15 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/03-multi-args.rs
+++ b/tests/exclude/03-multi-args.rs
@@ -1,0 +1,17 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(ident = Jovian, variants(Mercury, Venus, Earth, Mars), derive(Debug, PartialEq, Clone, Copy)))]
+#[exclude(arg(ident = Terrestrial, variants(Jupiter, Saturn, Uranus, Neptune), derive(Debug, PartialEq, Clone, Copy)))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/04-no-ident.rs
+++ b/tests/exclude/04-no-ident.rs
@@ -1,0 +1,19 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(
+    variants(Mercury, Venus, Earth, Mars),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/04-no-ident.stderr
+++ b/tests/exclude/04-no-ident.stderr
@@ -1,0 +1,9 @@
+error: Missing field `ident`
+ --> tests/exclude/04-no-ident.rs:4:11
+  |
+4 |   #[exclude(arg(
+  |  ___________^
+5 | |     variants(Mercury, Venus, Earth, Mars),
+6 | |     derive(Debug, PartialEq, Clone, Copy)
+7 | | ))]
+  | |_^

--- a/tests/exclude/05-empty-ident.rs
+++ b/tests/exclude/05-empty-ident.rs
@@ -1,0 +1,20 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(
+    ident = "",
+    variants(Mercury, Venus, Earth, Mars),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/05-empty-ident.stderr
+++ b/tests/exclude/05-empty-ident.stderr
@@ -1,0 +1,5 @@
+error: Unknown literal value ``
+ --> tests/exclude/05-empty-ident.rs:5:13
+  |
+5 |     ident = "",
+  |             ^^

--- a/tests/exclude/06-no-variants.rs
+++ b/tests/exclude/06-no-variants.rs
@@ -1,0 +1,19 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(
+    ident = Terrestrial,
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/06-no-variants.stderr
+++ b/tests/exclude/06-no-variants.stderr
@@ -1,0 +1,9 @@
+error: Missing field `variants`
+ --> tests/exclude/06-no-variants.rs:4:11
+  |
+4 |   #[exclude(arg(
+  |  ___________^
+5 | |     ident = Terrestrial,
+6 | |     derive(Debug, PartialEq, Clone, Copy)
+7 | | ))]
+  | |_^

--- a/tests/exclude/07-empty-variants.rs
+++ b/tests/exclude/07-empty-variants.rs
@@ -1,0 +1,20 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(
+    ident = Terrestrial,
+    variants(),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/exclude/07-empty-variants.stderr
+++ b/tests/exclude/07-empty-variants.stderr
@@ -1,0 +1,5 @@
+error: Too few items: Expected at least 1
+ --> tests/exclude/07-empty-variants.rs:6:5
+  |
+6 |     variants(),
+  |     ^^^^^^^^^^

--- a/tests/exclude/08-variant-not-exist.rs
+++ b/tests/exclude/08-variant-not-exist.rs
@@ -1,0 +1,20 @@
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude)]
+#[exclude(arg(
+    ident = Terrestrial,
+    variants(Foo, Bar),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -1,0 +1,15 @@
+use trybuild::TestCases;
+
+#[test]
+fn extract() {
+    let t = TestCases::new();
+
+    t.pass("tests/extract/01-ident.rs");
+    t.pass("tests/extract/02-zero-arg.rs");
+    t.pass("tests/extract/03-multi-args.rs");
+    t.compile_fail("tests/extract/04-no-ident.rs");
+    t.compile_fail("tests/extract/05-empty-ident.rs");
+    t.compile_fail("tests/extract/06-no-variants.rs");
+    t.compile_fail("tests/extract/07-empty-variants.rs");
+    t.pass("tests/extract/08-variant-not-exist.rs");
+}

--- a/tests/extract/01-ident.rs
+++ b/tests/extract/01-ident.rs
@@ -1,0 +1,22 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(ident = Terrestrial, variants(Mercury, Venus, Earth, Mars), derive(Debug, PartialEq, Clone, Copy)))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {
+    let terrestrial = Terrestrial::Earth;
+
+    let planet: Planet = terrestrial.into();
+
+    assert_eq!(planet, Planet::Earth);
+}

--- a/tests/extract/02-zero-arg.rs
+++ b/tests/extract/02-zero-arg.rs
@@ -1,0 +1,15 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/03-multi-args.rs
+++ b/tests/extract/03-multi-args.rs
@@ -1,0 +1,17 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(ident = Terrestrial, variants(Mercury, Venus, Earth, Mars), derive(Debug, PartialEq, Clone, Copy)))]
+#[extract(arg(ident = Jovian, variants(Jupiter, Saturn, Uranus, Neptune), derive(Debug, PartialEq, Clone, Copy)))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/04-no-ident.rs
+++ b/tests/extract/04-no-ident.rs
@@ -1,0 +1,19 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(
+    variants(Mercury, Venus, Earth, Mars),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/04-no-ident.stderr
+++ b/tests/extract/04-no-ident.stderr
@@ -1,0 +1,9 @@
+error: Missing field `ident`
+ --> tests/extract/04-no-ident.rs:4:11
+  |
+4 |   #[extract(arg(
+  |  ___________^
+5 | |     variants(Mercury, Venus, Earth, Mars),
+6 | |     derive(Debug, PartialEq, Clone, Copy)
+7 | | ))]
+  | |_^

--- a/tests/extract/05-empty-ident.rs
+++ b/tests/extract/05-empty-ident.rs
@@ -1,0 +1,20 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(
+    ident = "",
+    variants(Mercury, Venus, Earth, Mars),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/05-empty-ident.stderr
+++ b/tests/extract/05-empty-ident.stderr
@@ -1,0 +1,5 @@
+error: Unknown literal value ``
+ --> tests/extract/05-empty-ident.rs:5:13
+  |
+5 |     ident = "",
+  |             ^^

--- a/tests/extract/06-no-variants.rs
+++ b/tests/extract/06-no-variants.rs
@@ -1,0 +1,19 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(
+    ident = Terrestrial,
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/06-no-variants.stderr
+++ b/tests/extract/06-no-variants.stderr
@@ -1,0 +1,9 @@
+error: Missing field `variants`
+ --> tests/extract/06-no-variants.rs:4:11
+  |
+4 |   #[extract(arg(
+  |  ___________^
+5 | |     ident = Terrestrial,
+6 | |     derive(Debug, PartialEq, Clone, Copy)
+7 | | ))]
+  | |_^

--- a/tests/extract/07-empty-variants.rs
+++ b/tests/extract/07-empty-variants.rs
@@ -1,0 +1,20 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(
+    ident = Terrestrial,
+    variants(),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/extract/07-empty-variants.stderr
+++ b/tests/extract/07-empty-variants.stderr
@@ -1,0 +1,5 @@
+error: Too few items: Expected at least 1
+ --> tests/extract/07-empty-variants.rs:6:5
+  |
+6 |     variants(),
+  |     ^^^^^^^^^^

--- a/tests/extract/08-variant-not-exist.rs
+++ b/tests/extract/08-variant-not-exist.rs
@@ -1,0 +1,20 @@
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract)]
+#[extract(arg(
+    ident = Terrestrial,
+    variants(Foo, Bar),
+    derive(Debug, PartialEq, Clone, Copy)
+))]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {}

--- a/tests/omit.rs
+++ b/tests/omit.rs
@@ -1,0 +1,15 @@
+use trybuild::TestCases;
+
+#[test]
+fn omit() {
+    let t = TestCases::new();
+
+    t.pass("tests/omit/01-ident.rs");
+    t.pass("tests/omit/02-zero-arg.rs");
+    t.pass("tests/omit/03-multi-args.rs");
+    t.compile_fail("tests/omit/04-no-ident.rs");
+    t.compile_fail("tests/omit/05-no-fields.rs");
+    t.compile_fail("tests/omit/06-empty-fields.rs");
+    t.compile_fail("tests/omit/07-field-not-ident.rs");
+    t.pass("tests/omit/08-field-not-exist.rs");
+}

--- a/tests/omit/01-ident.rs
+++ b/tests/omit/01-ident.rs
@@ -1,0 +1,29 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, PartialEq)]
+#[omit(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let article = Article {
+        title: "Hello, world!".to_string(),
+        author: "Alice".to_string(),
+        content: "This is an article.".to_string(),
+        tags: vec!["hello".to_string(), "world".to_string()],
+    };
+
+    let meta: Meta = article.into();
+
+    assert_eq!(
+        meta,
+        Meta {
+            content: "This is an article.".to_string(),
+            tags: vec!["hello".to_string(), "world".to_string()],
+        }
+    );
+}

--- a/tests/omit/02-zero-arg.rs
+++ b/tests/omit/02-zero-arg.rs
@@ -1,0 +1,11 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, PartialEq)]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/omit/03-multi-args.rs
+++ b/tests/omit/03-multi-args.rs
@@ -1,0 +1,40 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq)))]
+#[omit(arg(ident = Meta2, fields(author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let article = Article {
+        title: "Hello, world!".to_string(),
+        author: "Alice".to_string(),
+        content: "This is an article.".to_string(),
+        tags: vec!["hello".to_string(), "world".to_string()],
+    };
+
+    let meta: Meta = article.clone().into();
+    let meta2: Meta2 = article.into();
+
+    assert_eq!(
+        meta,
+        Meta {
+            content: "This is an article.".to_string(),
+            tags: vec!["hello".to_string(), "world".to_string()],
+        }
+    );
+
+    assert_eq!(
+        meta2,
+        Meta2 {
+            title: "Hello, world!".to_string(),
+            content: "This is an article.".to_string(),
+            tags: vec!["hello".to_string(), "world".to_string()],
+        }
+    );
+}

--- a/tests/omit/04-no-ident.rs
+++ b/tests/omit/04-no-ident.rs
@@ -1,0 +1,12 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(fields(title, author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/omit/04-no-ident.stderr
+++ b/tests/omit/04-no-ident.stderr
@@ -1,0 +1,5 @@
+error: Missing field `ident`
+ --> tests/omit/04-no-ident.rs:4:8
+  |
+4 | #[omit(arg(fields(title, author), derive(Debug, PartialEq)))]
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/omit/05-no-fields.rs
+++ b/tests/omit/05-no-fields.rs
@@ -1,0 +1,12 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(ident = Meta, derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/omit/05-no-fields.stderr
+++ b/tests/omit/05-no-fields.stderr
@@ -1,0 +1,5 @@
+error: Missing field `fields`
+ --> tests/omit/05-no-fields.rs:4:8
+  |
+4 | #[omit(arg(ident = Meta, derive(Debug, PartialEq)))]
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/omit/06-empty-fields.rs
+++ b/tests/omit/06-empty-fields.rs
@@ -1,0 +1,12 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(ident = Meta, fields(), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/omit/06-empty-fields.stderr
+++ b/tests/omit/06-empty-fields.stderr
@@ -1,0 +1,5 @@
+error: Too few items: Expected at least 1
+ --> tests/omit/06-empty-fields.rs:4:26
+  |
+4 | #[omit(arg(ident = Meta, fields(), derive(Debug, PartialEq)))]
+  |                          ^^^^^^^^

--- a/tests/omit/07-field-not-ident.rs
+++ b/tests/omit/07-field-not-ident.rs
@@ -1,0 +1,12 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(ident = Meta, fields(foo::bar), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/omit/07-field-not-ident.stderr
+++ b/tests/omit/07-field-not-ident.stderr
@@ -1,0 +1,5 @@
+error: Unexpected type `non ident`
+ --> tests/omit/07-field-not-ident.rs:4:33
+  |
+4 | #[omit(arg(ident = Meta, fields(foo::bar), derive(Debug, PartialEq)))]
+  |                                 ^^^^^^^^

--- a/tests/omit/08-field-not-exist.rs
+++ b/tests/omit/08-field-not-exist.rs
@@ -1,0 +1,12 @@
+use utility_types::Omit;
+
+#[derive(Omit, Debug, Clone, PartialEq)]
+#[omit(arg(ident = Meta, fields(foo), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/partial.rs
+++ b/tests/partial.rs
@@ -1,0 +1,13 @@
+use trybuild::TestCases;
+
+#[test]
+fn partial() {
+    let t = TestCases::new();
+
+    t.pass("tests/partial/01-ident.rs");
+    t.compile_fail("tests/partial/02-no-ident.rs");
+    t.compile_fail("tests/partial/03-no-ident.rs");
+    t.compile_fail("tests/partial/04-no-ident.rs");
+    t.pass("tests/partial/05-ident-str.rs");
+    t.pass("tests/partial/06-derive-empty.rs");
+}

--- a/tests/partial/01-ident.rs
+++ b/tests/partial/01-ident.rs
@@ -1,0 +1,22 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial(ident = PartialA, derive(Debug, PartialEq))]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let a = A { a: 0, b: Some(1) };
+
+    let pa: PartialA = a.into();
+
+    assert_eq!(
+        pa,
+        PartialA {
+            a: Some(0),
+            b: Some(Some(1))
+        }
+    );
+}

--- a/tests/partial/02-no-ident.rs
+++ b/tests/partial/02-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/partial/02-no-ident.stderr
+++ b/tests/partial/02-no-ident.stderr
@@ -1,0 +1,7 @@
+error: Missing field `ident`
+ --> tests/partial/02-no-ident.rs:3:10
+  |
+3 | #[derive(Partial)]
+  |          ^^^^^^^
+  |
+  = note: this error originates in the derive macro `Partial` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/partial/03-no-ident.rs
+++ b/tests/partial/03-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial()]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/partial/03-no-ident.stderr
+++ b/tests/partial/03-no-ident.stderr
@@ -1,0 +1,7 @@
+error: Missing field `ident`
+ --> tests/partial/03-no-ident.rs:3:10
+  |
+3 | #[derive(Partial)]
+  |          ^^^^^^^
+  |
+  = note: this error originates in the derive macro `Partial` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/partial/04-no-ident.rs
+++ b/tests/partial/04-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial(ident)]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/partial/04-no-ident.stderr
+++ b/tests/partial/04-no-ident.stderr
@@ -1,0 +1,5 @@
+error: Unexpected meta-item format `word`
+ --> tests/partial/04-no-ident.rs:4:11
+  |
+4 | #[partial(ident)]
+  |           ^^^^^

--- a/tests/partial/05-ident-str.rs
+++ b/tests/partial/05-ident-str.rs
@@ -1,0 +1,22 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial(ident = "PartialA", derive(Debug, PartialEq))]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let a = A { a: 0, b: Some(1) };
+
+    let pa: PartialA = a.into();
+
+    assert_eq!(
+        pa,
+        PartialA {
+            a: Some(0),
+            b: Some(Some(1))
+        }
+    );
+}

--- a/tests/partial/06-derive-empty.rs
+++ b/tests/partial/06-derive-empty.rs
@@ -1,0 +1,10 @@
+use utility_types::Partial;
+
+#[derive(Partial)]
+#[partial(ident = PartialA, derive())]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/pick.rs
+++ b/tests/pick.rs
@@ -1,0 +1,15 @@
+use trybuild::TestCases;
+
+#[test]
+fn pick() {
+    let t = TestCases::new();
+
+    t.pass("tests/pick/01-ident.rs");
+    t.pass("tests/pick/02-zero-arg.rs");
+    t.pass("tests/pick/03-multi-args.rs");
+    t.compile_fail("tests/pick/04-no-ident.rs");
+    t.compile_fail("tests/pick/05-no-fields.rs");
+    t.compile_fail("tests/pick/06-empty-fields.rs");
+    t.compile_fail("tests/pick/07-field-not-ident.rs");
+    t.pass("tests/pick/08-field-not-exist.rs");
+}

--- a/tests/pick/01-ident.rs
+++ b/tests/pick/01-ident.rs
@@ -1,0 +1,29 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, PartialEq)]
+#[pick(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let article = Article {
+        title: "Hello, world!".to_string(),
+        author: "Alice".to_string(),
+        content: "This is an article.".to_string(),
+        tags: vec!["hello".to_string(), "world".to_string()],
+    };
+
+    let meta: Meta = article.into();
+
+    assert_eq!(
+        meta,
+        Meta {
+            title: "Hello, world!".to_string(),
+            author: "Alice".to_string(),
+        }
+    );
+}

--- a/tests/pick/02-zero-arg.rs
+++ b/tests/pick/02-zero-arg.rs
@@ -1,0 +1,11 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, PartialEq)]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/pick/03-multi-args.rs
+++ b/tests/pick/03-multi-args.rs
@@ -1,0 +1,38 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq)))]
+#[pick(arg(ident = Meta2, fields(author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let article = Article {
+        title: "Hello, world!".to_string(),
+        author: "Alice".to_string(),
+        content: "This is an article.".to_string(),
+        tags: vec!["hello".to_string(), "world".to_string()],
+    };
+
+    let meta: Meta = article.clone().into();
+    let meta2: Meta2 = article.into();
+
+    assert_eq!(
+        meta,
+        Meta {
+            title: "Hello, world!".to_string(),
+            author: "Alice".to_string(),
+        }
+    );
+
+    assert_eq!(
+        meta2,
+        Meta2 {
+            author: "Alice".to_string(),
+        }
+    );
+}

--- a/tests/pick/04-no-ident.rs
+++ b/tests/pick/04-no-ident.rs
@@ -1,0 +1,12 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(fields(title, author), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/pick/04-no-ident.stderr
+++ b/tests/pick/04-no-ident.stderr
@@ -1,0 +1,5 @@
+error: Missing field `ident`
+ --> tests/pick/04-no-ident.rs:4:8
+  |
+4 | #[pick(arg(fields(title, author), derive(Debug, PartialEq)))]
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/pick/05-no-fields.rs
+++ b/tests/pick/05-no-fields.rs
@@ -1,0 +1,12 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(ident = Meta, derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/pick/05-no-fields.stderr
+++ b/tests/pick/05-no-fields.stderr
@@ -1,0 +1,5 @@
+error: Missing field `fields`
+ --> tests/pick/05-no-fields.rs:4:8
+  |
+4 | #[pick(arg(ident = Meta, derive(Debug, PartialEq)))]
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/pick/06-empty-fields.rs
+++ b/tests/pick/06-empty-fields.rs
@@ -1,0 +1,12 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(ident = Meta, fields(), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/pick/06-empty-fields.stderr
+++ b/tests/pick/06-empty-fields.stderr
@@ -1,0 +1,5 @@
+error: Too few items: Expected at least 1
+ --> tests/pick/06-empty-fields.rs:4:26
+  |
+4 | #[pick(arg(ident = Meta, fields(), derive(Debug, PartialEq)))]
+  |                          ^^^^^^^^

--- a/tests/pick/07-field-not-ident.rs
+++ b/tests/pick/07-field-not-ident.rs
@@ -1,0 +1,12 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(ident = Meta, fields(foo::bar), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/pick/07-field-not-ident.stderr
+++ b/tests/pick/07-field-not-ident.stderr
@@ -1,0 +1,5 @@
+error: Unexpected type `non ident`
+ --> tests/pick/07-field-not-ident.rs:4:33
+  |
+4 | #[pick(arg(ident = Meta, fields(foo::bar), derive(Debug, PartialEq)))]
+  |                                 ^^^^^^^^

--- a/tests/pick/08-field-not-exist.rs
+++ b/tests/pick/08-field-not-exist.rs
@@ -1,0 +1,12 @@
+use utility_types::Pick;
+
+#[derive(Pick, Debug, Clone, PartialEq)]
+#[pick(arg(ident = Meta, fields(foo), derive(Debug, PartialEq)))]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/tests/required.rs
+++ b/tests/required.rs
@@ -1,0 +1,13 @@
+use trybuild::TestCases;
+
+#[test]
+fn required() {
+    let t = TestCases::new();
+
+    t.pass("tests/required/01-ident.rs");
+    t.compile_fail("tests/required/02-no-ident.rs");
+    t.compile_fail("tests/required/03-no-ident.rs");
+    t.compile_fail("tests/required/04-no-ident.rs");
+    t.pass("tests/required/05-ident-str.rs");
+    t.pass("tests/required/06-derive-empty.rs");
+}

--- a/tests/required/01-ident.rs
+++ b/tests/required/01-ident.rs
@@ -1,0 +1,14 @@
+use utility_types::Required;
+
+#[derive(Required, Debug, PartialEq)]
+#[required(ident = RequiredA, derive(Debug, PartialEq))]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let _a = A { a: 0, b: Some(1) };
+
+    let _ra: RequiredA = RequiredA { a: 0, b: 1 };
+}

--- a/tests/required/02-no-ident.rs
+++ b/tests/required/02-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Required;
+
+#[derive(Required)]
+#[required]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/required/02-no-ident.stderr
+++ b/tests/required/02-no-ident.stderr
@@ -1,0 +1,7 @@
+error: Missing field `ident`
+ --> tests/required/02-no-ident.rs:3:10
+  |
+3 | #[derive(Required)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Required` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/required/03-no-ident.rs
+++ b/tests/required/03-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Required;
+
+#[derive(Required)]
+#[required()]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/required/03-no-ident.stderr
+++ b/tests/required/03-no-ident.stderr
@@ -1,0 +1,7 @@
+error: Missing field `ident`
+ --> tests/required/03-no-ident.rs:3:10
+  |
+3 | #[derive(Required)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Required` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/required/04-no-ident.rs
+++ b/tests/required/04-no-ident.rs
@@ -1,0 +1,10 @@
+use utility_types::Required;
+
+#[derive(Required)]
+#[required(ident)]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}

--- a/tests/required/04-no-ident.stderr
+++ b/tests/required/04-no-ident.stderr
@@ -1,0 +1,5 @@
+error: Unexpected meta-item format `word`
+ --> tests/required/04-no-ident.rs:4:12
+  |
+4 | #[required(ident)]
+  |            ^^^^^

--- a/tests/required/05-ident-str.rs
+++ b/tests/required/05-ident-str.rs
@@ -1,0 +1,14 @@
+use utility_types::Required;
+
+#[derive(Required, Debug, PartialEq)]
+#[required(ident = "RequiredA", derive(Debug, PartialEq))]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let _a = A { a: 0, b: Some(1) };
+
+    let _ra: RequiredA = RequiredA { a: 0, b: 1 };
+}

--- a/tests/required/06-derive-empty.rs
+++ b/tests/required/06-derive-empty.rs
@@ -1,0 +1,10 @@
+use utility_types::Required;
+
+#[derive(Required)]
+#[required(ident = RequiredA, derive())]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {}


### PR DESCRIPTION
The former impl uses attribute macro, which needs to keep the original input. Since we don't need to modify the input, it is better to use derive instead.

In addition, all impl are split into separate modules. Only the exported macro and doc are in the main lib.rs.

BREAKING CHANGE: The macro is now derive macro