### PR TITLE
feat: add forward_attrs to all macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 proc-macro = true
 
 [dependencies]
-darling = "0.20.9"
-proc-macro2 = "1.0.85"
+darling = "0.20.10"
+proc-macro2 = "1.0.86"
 quote = "1.0.36"
-syn = { version = "2.0.66", features = ["full"] }
+syn = { version = "2.0.72", features = ["full"] }
 
 [dev-dependencies]
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.121"
-trybuild = { version = "1.0.96", features = ["diff"] }
+trybuild = { version = "1.0.98", features = ["diff"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ quote = "1.0.36"
 syn = { version = "2.0.66", features = ["full"] }
 
 [dev-dependencies]
+serde = { version = "1.0.204", features = ["derive"] }
+serde_json = "1.0.121"
 trybuild = { version = "1.0.96", features = ["diff"] }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,33 @@ Some useful traits are also generated:
 - `From<Foo>` for `PartialFoo`, `PickAB`, `OmitCD`
 - `From<PartialFoo>` for `Foo`
 
+### Forwarding Attributes
+
+To use this crate with other crates that need attributes, you can use the `forward_attrs` attribute to control which attributes are forwarded to the generated struct or enum.
+
+```rust
+use serde::{Deserialize, Serialize};
+use utility_types::Omit;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Omit)]
+#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde)))]
+#[serde(rename_all = "UPPERCASE")]
+pub struct Foo {
+    a: u8,
+    b: Option<u8>,
+    c: Option<Vec<u8>>,
+}
+
+let omit_cd: OmitCD = serde_json::from_str(r#"{"A": 1, "B": 2}"#).unwrap();
+assert_eq!(omit_cd, OmitCD { a: 1, b: Some(2) });
+```
+
+If the `forward_attrs` attribute is not specified, default attributes are forwarded:
+
+- `allow`
+- `cfg`
+- `doc`
+
 ## Known Issue
 
 Currently I don't analyze which generic is used in the generated struct or enum. So rustc will complain if the field with generic is not included in the generated struct or enum.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Here is an example of how to use this crate.
 ```rust
 use utility_types::{Omit, Partial, Pick, Required};
 #[derive(Clone, Partial, Required, Pick, Omit)]
-#[partial(ident = PartialFoo, derive(Debug, PartialEq))]
-#[required(ident = RequiredFoo, derive(Debug, PartialEq))]
-#[pick(arg(ident = PickAB, fields(a, b), derive(Debug, PartialEq)))]
-#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq)))]
+#[partial(ident = PartialFoo, derive(Debug, PartialEq), forward_attrs())]
+#[required(ident = RequiredFoo, derive(Debug, PartialEq), forward_attrs())]
+#[pick(arg(ident = PickAB, fields(a, b), derive(Debug, PartialEq)), forward_attrs())]
+#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq)), forward_attrs())]
 pub struct Foo {
     a: u8,
     b: Option<u8>,
@@ -69,7 +69,14 @@ use serde::{Deserialize, Serialize};
 use utility_types::Omit;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Omit)]
-#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde)))]
+#[omit(
+    arg(
+        ident = OmitCD,
+        fields(c, d),
+        derive(Debug, PartialEq, Serialize, Deserialize),
+        forward_attrs(serde)
+    )
+)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct Foo {
     a: u8,
@@ -81,11 +88,15 @@ let omit_cd: OmitCD = serde_json::from_str(r#"{"A": 1, "B": 2}"#).unwrap();
 assert_eq!(omit_cd, OmitCD { a: 1, b: Some(2) });
 ```
 
-If the `forward_attrs` attribute is not specified, default attributes are forwarded:
+The behavior of the `forward_attrs` attribute is as follows:
 
-- `allow`
-- `cfg`
-- `doc`
+- If **not provided**, all attributes are forwarded by default.
+- If provided with a list of attributes, only the specified attributes are forwarded.
+  - For example, `forward_attrs(doc, serde)` will forward only `doc` and `serde`.
+  - If provided with **only `*`** (`forward_attrs(*)`), all attributes are forwarded.
+  - If provided with **an empty list** (`forward_attrs()`), no attributes are forwarded.
+- If provided with a list inside `not()`, all attributes except the specified attributes are forwarded.
+  - For example, `forward_attrs(not(serde))` will forward all attributes except `serde`.
 
 ## Known Issue
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -7,7 +7,7 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Attribute, Field, Generics, Ident, Visibility};
 
-use crate::utils::IdentList;
+use crate::utils::{default_forward_attrs_filter, IdentList};
 
 #[derive(Debug, FromMeta)]
 struct ExtractArgs {
@@ -16,6 +16,8 @@ struct ExtractArgs {
     variants: IdentList,
 
     derive: Option<PathList>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug)]
@@ -44,7 +46,7 @@ impl FromMeta for ExtractArgsList {
 }
 
 #[derive(Debug, FromVariant)]
-#[darling(attributes(extract), forward_attrs(allow, doc, cfg))]
+#[darling(attributes(extract), forward_attrs)]
 struct ExtractVariant {
     ident: Ident,
 
@@ -53,14 +55,12 @@ struct ExtractVariant {
     fields: Fields<Field>,
 
     attrs: Vec<Attribute>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(
-    attributes(extract),
-    forward_attrs(allow, doc, cfg),
-    supports(enum_any)
-)]
+#[darling(attributes(extract), forward_attrs, supports(enum_any))]
 struct ExtractInput {
     ident: Ident,
 
@@ -69,6 +69,11 @@ struct ExtractInput {
     generics: Generics,
 
     data: Data<ExtractVariant, Ignored>,
+
+    attrs: Vec<Attribute>,
+
+    /// The filter for attributes to forward to the generated enum.
+    forward_attrs: Option<PathList>,
 
     #[darling(flatten)]
     args: ExtractArgsList,
@@ -90,15 +95,18 @@ pub fn extract(input: TokenStream) -> TokenStream {
     let variants = input.data.take_enum().unwrap();
 
     let extracts = input.args.iter().map(|arg| {
-        let derive_attr = match &arg.derive {
-            Some(derives) => {
-                let derives = derives.iter();
-                quote! {
-                    #[derive(#(#derives),*)]
-                }
+        let derive_attr = arg.derive.as_ref().map(|derives| {
+            let derives = derives.iter();
+            quote! {
+                #[derive(#(#derives),*)]
             }
-            None => quote! {},
-        };
+        });
+
+        let forward_attrs = arg.forward_attrs.as_ref().or(input.forward_attrs.as_ref());
+        let forward_attrs = input.attrs.iter().filter(|attr| match forward_attrs {
+            Some(filter) => filter.contains(attr.path()),
+            None => default_forward_attrs_filter(attr.path()),
+        });
 
         let extract_ident = &arg.ident;
 
@@ -114,13 +122,22 @@ pub fn extract(input: TokenStream) -> TokenStream {
                 return;
             }
 
-            let attrs = &variant.attrs;
+            let forward_attrs = variant
+                .forward_attrs
+                .as_ref()
+                .or(arg.forward_attrs.as_ref())
+                .or(input.forward_attrs.as_ref());
+            let forward_attrs = variant.attrs.iter().filter(|attr| match forward_attrs {
+                Some(filter) => filter.contains(attr.path()),
+                None => default_forward_attrs_filter(attr.path()),
+            });
+
             let fields = &variant.fields;
             let discriminant = &variant.discriminant;
 
             variant_idents.push(variant_ident);
             variant_declares.push(quote! {
-                #(#attrs)*
+                #(#forward_attrs)*
                 #variant_ident #fields #discriminant
             });
             variant_from_extract.push(match fields.style {
@@ -128,26 +145,32 @@ pub fn extract(input: TokenStream) -> TokenStream {
                     #extract_ident::#variant_ident => #ident::#variant_ident
                 },
                 Style::Tuple => {
-                    let field_idents = (0..fields.len()).map(|i| format_ident!("F{i}")).collect::<Vec<_>>();
+                    let field_idents = (0..fields.len())
+                        .map(|i| format_ident!("F{i}"))
+                        .collect::<Vec<_>>();
 
                     quote! {
                         #extract_ident::#variant_ident(#(#field_idents),*) => #ident::#variant_ident(#(#field_idents),*)
                     }
-                }
+                },
                 Style::Struct => {
-                    let field_idents = fields.iter().map(|field| field.ident.as_ref().unwrap()).collect::<Vec<_>>();
+                    let field_idents = fields
+                        .iter()
+                        .map(|field| field.ident.as_ref().unwrap())
+                        .collect::<Vec<_>>();
 
                     quote! {
                         #extract_ident::#variant_ident { #(#field_idents),* } => #ident::#variant_ident { #(#field_idents),* }
                     }
                 }
-            })
+            });
         });
 
         // TODO: Generics may not be needed in the generated struct
         // It may be better to check all fields for generics
         quote! {
             #derive_attr
+            #(#forward_attrs)*
             #vis enum #extract_ident #generics {
                 #(#variant_declares),*
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod required;
 /// Utility functions and types.
 mod utils;
 
-/// Constructs a struct with all fields of the original struct set to optional.
+/// Constructs a struct with all fields of the original struct set to **optional**.
 ///
 /// ## Example
 ///
@@ -58,14 +58,12 @@ mod utils;
 /// #[partial(
 ///     ident = <IDENT>, // The identifier of the generated struct
 ///     [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated struct
 /// )]
 /// pub struct BasedStruct {
 ///     #[partial(
 ///         [default = <DEFAULT>], // The default value of the field in the generated From impl
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated field
 ///             // If given, will override the container level `forward_attrs`
 ///     )]
 ///     field: FieldType,
@@ -76,7 +74,7 @@ pub fn partial(input: TokenStream) -> TokenStream {
     partial::partial(input)
 }
 
-/// Constructs a struct with all fields of the original struct set to required.
+/// Constructs a struct with all fields of the original struct set to **required**.
 ///
 /// ## Example
 ///
@@ -107,13 +105,11 @@ pub fn partial(input: TokenStream) -> TokenStream {
 /// #[required(
 ///     ident = <IDENT>, // The identifier of the generated struct
 ///     [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated struct
 /// )]
 /// pub struct BasedStruct {
 ///     #[required(
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated field
 ///             // If given, will override the container level `forward_attrs`
 ///     )]
 ///     field: FieldType,
@@ -124,15 +120,17 @@ pub fn required(input: TokenStream) -> TokenStream {
     required::required(input)
 }
 
-/// Constructs a struct by picking the set of fields from the original struct.
+/// Constructs structs by **picking** the set of fields from the original struct.
 ///
 /// ## Example
 ///
 /// ```ignore
 /// # use utility_types::Pick;
 /// #[derive(Pick)]
-/// #[pick(arg(ident = AuthorContent, fields(author, content), derive(Debug)))]
-/// #[pick(arg(ident = LikedComments, fields(liked, comments)))]
+/// #[pick(
+///     arg(ident = AuthorContent, fields(author, content), derive(Debug)),
+///     arg(ident = LikedComments, fields(liked, comments))
+/// )]
 /// pub struct Article {
 ///     author: String,
 ///     content: String,
@@ -166,22 +164,18 @@ pub fn required(input: TokenStream) -> TokenStream {
 /// # use utility_types::Pick;
 /// #[derive(Pick)]
 /// #[pick(
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
-/// )]
-/// #[pick(
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to all generated structs
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated struct
 ///         fields(<FIELD>, ...), // The fields to pick from the original struct
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated struct
 ///             // If given, will override the container level `forward_attrs`
-///     ),
+///     ), ...
 /// )]
 /// pub struct BasedStruct {
 ///     #[pick(
-///         #[forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///         #[forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated field
 ///             // If given, will override the container level and arg level `forward_attrs`
 ///     )]
 ///     field: FieldType,
@@ -191,15 +185,17 @@ pub fn pick(input: TokenStream) -> TokenStream {
     pick::pick(input)
 }
 
-/// Constructs a struct by omitting the set of fields from the original struct.
+/// Constructs structs by **omitting** the set of fields from the original struct.
 ///
 /// ## Example
 ///
 /// ```
 /// # use utility_types::Omit;
 /// #[derive(Omit)]
-/// #[omit(arg(ident = OmitAuthorContent, fields(author, content), derive(Debug)))]
-/// #[omit(arg(ident = OmitLikedComments, fields(liked, comments)))]
+/// #[omit(
+///     arg(ident = OmitAuthorContent, fields(author, content), derive(Debug)),
+///     arg(ident = OmitLikedComments, fields(liked, comments))
+/// )]
 /// pub struct Article {
 ///     author: String,
 ///     content: String,
@@ -233,22 +229,18 @@ pub fn pick(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Omit)]
 /// #[omit(
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
-/// )]
-/// #[omit(
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to all generated structs
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated struct
 ///         fields(<FIELD>, ...), // The fields to omit from the original struct
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated struct
 ///             // If given, will override the container level `forward_attrs`
-///     ),
+///     ), ...
 /// )]
 /// pub struct BasedStruct {
 ///     #[omit(
-///         #[forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///         #[forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated field
 ///             // If given, will override the container level and arg level `forward_attrs`
 ///     )]
 ///     field: FieldType,
@@ -259,7 +251,7 @@ pub fn omit(input: TokenStream) -> TokenStream {
     omit::omit(input)
 }
 
-/// Constructs an enum by extracting the set of variants from the original enum.
+/// Constructs enums by **extracting** the set of variants from the original enum.
 ///
 /// ## Example
 ///
@@ -288,22 +280,18 @@ pub fn omit(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Extract)]
 /// #[extract(
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
-/// )]
-/// #[extract(
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to all generated enums
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated enum
 ///         variants(<VARIANT>, ...), // The variants to extract from the original enum
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated enum
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated enum
 ///             // If given, will override the container level `forward_attrs`
-///     ),
+///     ), ...
 /// )]
 /// pub enum BasedEnum {
 ///     #[extract(
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated variant
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated variant
 ///             // If given, will override the container level and arg level `forward_attrs`
 ///     )]
 ///     variant: VariantType,
@@ -314,7 +302,7 @@ pub fn extract(input: TokenStream) -> TokenStream {
     extract::extract(input)
 }
 
-/// Constructs an enum by excluding the set of variants from the original enum.
+/// Constructs enums by **excluding** the set of variants from the original enum.
 ///
 /// ## Example
 ///
@@ -345,22 +333,18 @@ pub fn extract(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Exclude)]
 /// #[exclude(
-///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
-///         // If no attributes are specified, default attributes are forwarded
-///         // `allow`, `cfg`, and `doc`
-/// )]
-/// #[exclude(
+///     [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to all generated enums
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated enum
 ///         variants(<VARIANT>, ...), // The variants to exclude from the original enum
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated enum
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated enum
 ///             // If given, will override the container level `forward_attrs`
 ///     ),
 /// )]
 /// pub enum BasedEnum {
 ///     #[exclude(
-///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated variant
+///         [forward_attrs(<ATTR, ...> | not(<ATTR, ...>))], // Forward specific attributes to the generated variant
 ///             // If given, will override the container level and arg level `forward_attrs`
 ///     )]
 ///     variant: VariantType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,15 @@ mod utils;
 /// #[partial(
 ///     ident = <IDENT>, // The identifier of the generated struct
 ///     [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
 /// )]
 /// pub struct BasedStruct {
 ///     #[partial(
 ///         [default = <DEFAULT>], // The default value of the field in the generated From impl
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///             // If given, will override the container level `forward_attrs`
 ///     )]
 ///     field: FieldType,
 /// }
@@ -102,8 +107,15 @@ pub fn partial(input: TokenStream) -> TokenStream {
 /// #[required(
 ///     ident = <IDENT>, // The identifier of the generated struct
 ///     [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
 /// )]
 /// pub struct BasedStruct {
+///     #[required(
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///             // If given, will override the container level `forward_attrs`
+///     )]
 ///     field: FieldType,
 /// }
 /// ```
@@ -154,13 +166,24 @@ pub fn required(input: TokenStream) -> TokenStream {
 /// # use utility_types::Pick;
 /// #[derive(Pick)]
 /// #[pick(
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
+/// )]
+/// #[pick(
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated struct
 ///         fields(<FIELD>, ...), // The fields to pick from the original struct
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///             // If given, will override the container level `forward_attrs`
 ///     ),
 /// )]
 /// pub struct BasedStruct {
+///     #[pick(
+///         #[forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///             // If given, will override the container level and arg level `forward_attrs`
+///     )]
 ///     field: FieldType,
 /// }
 #[proc_macro_derive(Pick, attributes(pick))]
@@ -210,13 +233,24 @@ pub fn pick(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Omit)]
 /// #[omit(
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
+/// )]
+/// #[omit(
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated struct
 ///         fields(<FIELD>, ...), // The fields to omit from the original struct
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated struct
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated struct
+///             // If given, will override the container level `forward_attrs`
 ///     ),
 /// )]
 /// pub struct BasedStruct {
+///     #[omit(
+///         #[forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated field
+///             // If given, will override the container level and arg level `forward_attrs`
+///     )]
 ///     field: FieldType,
 /// }
 /// ```
@@ -254,13 +288,24 @@ pub fn omit(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Extract)]
 /// #[extract(
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
+/// )]
+/// #[extract(
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated enum
 ///         variants(<VARIANT>, ...), // The variants to extract from the original enum
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated enum
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///             // If given, will override the container level `forward_attrs`
 ///     ),
 /// )]
 /// pub enum BasedEnum {
+///     #[extract(
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated variant
+///             // If given, will override the container level and arg level `forward_attrs`
+///     )]
 ///     variant: VariantType,
 /// }
 /// ```
@@ -300,13 +345,24 @@ pub fn extract(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(Exclude)]
 /// #[exclude(
+///     [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///         // If no attributes are specified, default attributes are forwarded
+///         // `allow`, `cfg`, and `doc`
+/// )]
+/// #[exclude(
 ///     arg(
 ///         ident = <IDENT>, // The identifier of the generated enum
 ///         variants(<VARIANT>, ...), // The variants to exclude from the original enum
 ///         [derive(<DERIVE>, ...)], // Derive attributes for the generated enum
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated enum
+///             // If given, will override the container level `forward_attrs`
 ///     ),
 /// )]
 /// pub enum BasedEnum {
+///     #[exclude(
+///         [forward_attrs(<ATTR>, ...)], // Forward specific attributes to the generated variant
+///             // If given, will override the container level and arg level `forward_attrs`
+///     )]
 ///     variant: VariantType,
 /// }
 /// ```

--- a/src/omit.rs
+++ b/src/omit.rs
@@ -7,7 +7,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Attribute, Generics, Ident, Type, Visibility};
 
-use crate::utils::IdentList;
+use crate::utils::{default_forward_attrs_filter, IdentList};
 
 #[derive(Debug, FromMeta)]
 struct OmitArgs {
@@ -16,6 +16,8 @@ struct OmitArgs {
     fields: IdentList,
 
     derive: Option<PathList>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug)]
@@ -44,7 +46,7 @@ impl FromMeta for OmitArgsList {
 }
 
 #[derive(Debug, FromField)]
-#[darling(attributes(omit), forward_attrs(allow, doc, cfg))]
+#[darling(attributes(omit), forward_attrs)]
 struct OmitField {
     ident: Option<Ident>,
 
@@ -53,14 +55,12 @@ struct OmitField {
     ty: Type,
 
     attrs: Vec<Attribute>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(
-    attributes(omit),
-    forward_attrs(allow, doc, cfg),
-    supports(struct_named)
-)]
+#[darling(attributes(omit), forward_attrs, supports(struct_named))]
 struct OmitInput {
     ident: Ident,
 
@@ -70,6 +70,12 @@ struct OmitInput {
 
     data: Data<Ignored, OmitField>,
 
+    attrs: Vec<Attribute>,
+
+    /// The filter for attributes to forward to the generated struct
+    forward_attrs: Option<PathList>,
+
+    /// Args for each generated struct
     #[darling(flatten)]
     args: OmitArgsList,
 }
@@ -90,15 +96,18 @@ pub fn omit(input: TokenStream) -> TokenStream {
     let fields = input.data.take_struct().unwrap();
 
     let omits = input.args.iter().map(|arg| {
-        let derive_attr = match &arg.derive {
-            Some(derives) => {
-                let derives = derives.iter();
-                quote! {
-                    #[derive(#(#derives),*)]
-                }
+        let derive_attr = arg.derive.as_ref().map(|derives| {
+            let derives = derives.iter();
+            quote! {
+                #[derive(#(#derives),*)]
             }
-            None => quote! {},
-        };
+        });
+
+        let forward_attrs = arg.forward_attrs.as_ref().or(input.forward_attrs.as_ref());
+        let forward_attrs = input.attrs.iter().filter(|attr| match forward_attrs {
+            Some(filter) => filter.contains(attr.path()),
+            None => default_forward_attrs_filter(attr.path()),
+        });
 
         let omit_ident = &arg.ident;
 
@@ -113,13 +122,22 @@ pub fn omit(input: TokenStream) -> TokenStream {
                 return;
             }
 
-            let attrs = &field.attrs;
+            let forward_attrs = field
+                .forward_attrs
+                .as_ref()
+                .or(arg.forward_attrs.as_ref())
+                .or(input.forward_attrs.as_ref());
+            let forward_attrs = field.attrs.iter().filter(|attr| match forward_attrs {
+                Some(filter) => filter.contains(attr.path()),
+                None => default_forward_attrs_filter(attr.path()),
+            });
+
             let vis = &field.vis;
             let ty = &field.ty;
 
             field_idents.push(ident);
             field_declares.push(quote! {
-                #(#attrs)*
+                #(#forward_attrs)*
                 #vis #ident: #ty,
             });
         });
@@ -128,6 +146,7 @@ pub fn omit(input: TokenStream) -> TokenStream {
         // It may be better to check all fields for generics
         quote! {
             #derive_attr
+            #(#forward_attrs)*
             #vis struct #omit_ident #generics {
                 #(#field_declares)*
             }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -5,15 +5,19 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Attribute, Generics, Ident, Type, Visibility};
 
+use crate::utils::default_forward_attrs_filter;
+
 #[derive(Debug, FromMeta)]
 struct PartialArgs {
     ident: Ident,
 
     derive: Option<PathList>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug, FromField)]
-#[darling(attributes(partial), forward_attrs(allow, doc, cfg))]
+#[darling(attributes(partial), forward_attrs)]
 struct PartialField {
     ident: Option<Ident>,
 
@@ -24,12 +28,14 @@ struct PartialField {
     attrs: Vec<Attribute>,
 
     default: Option<syn::Expr>,
+
+    forward_attrs: Option<PathList>,
 }
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(
     attributes(partial),
-    forward_attrs(allow, doc, cfg),
+    forward_attrs,
     supports(struct_named, struct_tuple)
 )]
 struct PartialInput {
@@ -40,6 +46,8 @@ struct PartialInput {
     generics: Generics,
 
     data: Data<Ignored, PartialField>,
+
+    attrs: Vec<Attribute>,
 
     #[darling(flatten)]
     args: PartialArgs,
@@ -55,15 +63,21 @@ pub fn partial(input: TokenStream) -> TokenStream {
         }
     };
 
-    let derive_attr = match input.args.derive {
-        Some(derives) => {
-            let derives = derives.iter();
-            quote! {
-                #[derive(#(#derives),*)]
-            }
+    let derive_attr = input.args.derive.as_ref().map(|derives| {
+        let derives = derives.iter();
+        quote! {
+            #[derive(#(#derives),*)]
         }
-        None => quote! {},
-    };
+    });
+
+    let forward_attrs = input
+        .attrs
+        .iter()
+        .filter(|attr| match input.args.forward_attrs.as_ref() {
+            Some(filter) => filter.contains(attr.path()),
+            None => default_forward_attrs_filter(attr.path()),
+        });
+
     let vis = input.vis;
     let ident = input.ident;
     let partial_ident = input.args.ident;
@@ -77,7 +91,15 @@ pub fn partial(input: TokenStream) -> TokenStream {
     fields.fields.iter().for_each(|field| {
         let vis = &field.vis;
         let ident = field.ident.as_ref().unwrap();
-        let attrs = &field.attrs;
+
+        let forward_attrs = field
+            .forward_attrs
+            .as_ref()
+            .or(input.args.forward_attrs.as_ref());
+        let forward_attrs = field.attrs.iter().filter(|attr| match forward_attrs {
+            Some(filter) => filter.contains(attr.path()),
+            None => default_forward_attrs_filter(attr.path()),
+        });
 
         let ty = &field.ty;
         // TODO: It may be better to keep the original type if it is already an Option
@@ -85,7 +107,7 @@ pub fn partial(input: TokenStream) -> TokenStream {
 
         field_idents.push(ident.clone());
         field_declares.push(quote! {
-            #(#attrs)*
+            #(#forward_attrs)*
             #vis #ident: #ty
         });
         field_from_partial.push(match &field.default {
@@ -100,6 +122,7 @@ pub fn partial(input: TokenStream) -> TokenStream {
 
     quote! {
         #derive_attr
+        #(#forward_attrs)*
         #vis struct #partial_ident #generics {
             #(#field_declares),*
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,9 @@
-use std::ops::Deref;
+use std::ops::{Add, Deref};
 
+use darling::ast::NestedMeta;
+use darling::util::PathList;
 use darling::FromMeta;
-use syn::{Ident, Meta, Path};
+use syn::{Attribute, Ident, Meta};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct IdentList(Vec<Ident>);
@@ -27,11 +29,11 @@ impl From<Vec<Ident>> for IdentList {
 }
 
 impl FromMeta for IdentList {
-    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
         let values = items
             .iter()
             .map(|item| match item {
-                darling::ast::NestedMeta::Meta(Meta::Path(path)) => match path.get_ident() {
+                NestedMeta::Meta(Meta::Path(path)) => match path.get_ident() {
                     Some(ident) => Ok(ident.clone()),
                     None => Err(darling::Error::unexpected_type("non ident").with_span(item)),
                 },
@@ -49,8 +51,72 @@ impl FromMeta for IdentList {
     }
 }
 
-pub fn default_forward_attrs_filter(path: &Path) -> bool {
-    ["allow", "cfg", "doc"]
-        .iter()
-        .any(|attr| path.is_ident(attr))
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum ForwardAttrsFilter {
+    // forward all attributes
+    #[default]
+    All,
+
+    // forward only specific attributes
+    Some(PathList),
+
+    // forward all attributes except specific ones
+    Not(PathList),
+}
+
+impl Add for &ForwardAttrsFilter {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        // The lhs should be the smaller scope (field, arg)
+        // The rhs should be the larger scope (arg, container)
+        // Currently, we implement this simply by always using the lhs if it is not `All`
+        // TODO: A more appropriate way should be discussed and implemented
+        match (self, rhs) {
+            (ForwardAttrsFilter::All, _) => rhs,
+            _ => self,
+        }
+    }
+}
+
+impl FromMeta for ForwardAttrsFilter {
+    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
+        if items.len() == 1 {
+            match &items[0] {
+                NestedMeta::Meta(Meta::Path(path)) => {
+                    if path.is_ident("*") {
+                        Ok(Self::All)
+                    } else {
+                        Ok(Self::Some(PathList::from_list(&[items[0].clone()])?))
+                    }
+                }
+                NestedMeta::Meta(Meta::List(list)) => {
+                    if list.path.is_ident("not") {
+                        Ok(Self::Not(PathList::from_list(
+                            &NestedMeta::parse_meta_list(list.tokens.clone())?[..],
+                        )?))
+                    } else {
+                        Err(
+                            darling::Error::unknown_value("expected `not(attr1, attr2, ...)`")
+                                .with_span(&items[0]),
+                        )
+                    }
+                }
+                _ => Err(darling::Error::unexpected_type("non path or list").with_span(&items[0])),
+            }
+        } else {
+            Ok(Self::Some(PathList::from_list(items)?))
+        }
+    }
+}
+
+pub fn filter_forward_attrs<'a>(
+    attrs: impl Iterator<Item = &'a Attribute> + 'a,
+    filter: &'a ForwardAttrsFilter,
+) -> impl Iterator<Item = &'a Attribute> + 'a {
+    attrs.filter(move |attr| match filter {
+        ForwardAttrsFilter::All => true,
+        ForwardAttrsFilter::Some(allowed) => allowed.contains(attr.path()),
+        ForwardAttrsFilter::Not(not_allowed) => !not_allowed.contains(attr.path()),
+    })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use darling::FromMeta;
-use syn::{Ident, Meta};
+use syn::{Ident, Meta, Path};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct IdentList(Vec<Ident>);
@@ -47,4 +47,10 @@ impl FromMeta for IdentList {
 
         Ok(Self::new(values))
     }
+}
+
+pub fn default_forward_attrs_filter(path: &Path) -> bool {
+    ["allow", "cfg", "doc"]
+        .iter()
+        .any(|attr| path.is_ident(attr))
 }

--- a/tests/exclude.rs
+++ b/tests/exclude.rs
@@ -12,4 +12,5 @@ fn exclude() {
     t.compile_fail("tests/exclude/06-no-variants.rs");
     t.compile_fail("tests/exclude/07-empty-variants.rs");
     t.pass("tests/exclude/08-variant-not-exist.rs");
+    t.pass("tests/exclude/09-forward-attrs.rs");
 }

--- a/tests/exclude/09-forward-attrs.rs
+++ b/tests/exclude/09-forward-attrs.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Exclude;
+
+#[derive(Debug, PartialEq, Exclude, Serialize, Deserialize)]
+#[exclude(forward_attrs(serde))]
+#[exclude(arg(ident = Terrestrial, variants(Jupiter, Saturn, Uranus, Neptune), derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)))]
+#[serde(rename_all = "snake_case")]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {
+    let terrestrial: Terrestrial = serde_json::from_str(r#""mercury""#).unwrap();
+
+    assert_eq!(terrestrial, Terrestrial::Mercury);
+}

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -12,4 +12,5 @@ fn extract() {
     t.compile_fail("tests/extract/06-no-variants.rs");
     t.compile_fail("tests/extract/07-empty-variants.rs");
     t.pass("tests/extract/08-variant-not-exist.rs");
+    t.pass("tests/extract/09-forward-attrs.rs");
 }

--- a/tests/extract/09-forward-attrs.rs
+++ b/tests/extract/09-forward-attrs.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Extract;
+
+#[derive(Debug, PartialEq, Extract, Serialize, Deserialize)]
+#[extract(forward_attrs(serde))]
+#[extract(arg(ident = Terrestrial, variants(Mercury, Venus, Earth, Mars), derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)))]
+#[serde(rename_all = "snake_case")]
+pub enum Planet {
+    Mercury,
+    Venus,
+    Earth,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+}
+
+fn main() {
+    let terrestrial: Terrestrial = serde_json::from_str(r#""mercury""#).unwrap();
+
+    assert_eq!(terrestrial, Terrestrial::Mercury);
+}

--- a/tests/omit.rs
+++ b/tests/omit.rs
@@ -12,4 +12,5 @@ fn omit() {
     t.compile_fail("tests/omit/06-empty-fields.rs");
     t.compile_fail("tests/omit/07-field-not-ident.rs");
     t.pass("tests/omit/08-field-not-exist.rs");
+    t.pass("tests/omit/09-forward-attrs.rs");
 }

--- a/tests/omit/09-forward-attrs.rs
+++ b/tests/omit/09-forward-attrs.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Omit;
+
+#[derive(Omit, Debug, PartialEq, Serialize, Deserialize)]
+#[omit(forward_attrs(serde))]
+#[omit(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq, Serialize, Deserialize)))]
+#[serde(rename_all = "UPPERCASE")]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let meta: Meta = serde_json::from_str(
+        r#"{
+            "CONTENT": "This is an article.",
+            "TAGS": ["hello", "world"]
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        meta,
+        Meta {
+            content: "This is an article.".to_string(),
+            tags: vec!["hello".to_string(), "world".to_string()],
+        }
+    );
+}

--- a/tests/partial.rs
+++ b/tests/partial.rs
@@ -10,4 +10,5 @@ fn partial() {
     t.compile_fail("tests/partial/04-no-ident.rs");
     t.pass("tests/partial/05-ident-str.rs");
     t.pass("tests/partial/06-derive-empty.rs");
+    t.pass("tests/partial/07-forward-attrs.rs");
 }

--- a/tests/partial/07-forward-attrs.rs
+++ b/tests/partial/07-forward-attrs.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Partial;
+
+#[derive(Partial, Serialize, Deserialize)]
+#[partial(ident = PartialA, derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde))]
+#[serde(rename_all = "UPPERCASE")]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let a: PartialA = serde_json::from_str(r#"{"A":0,"B":1}"#).unwrap();
+
+    assert_eq!(
+        a,
+        PartialA {
+            a: Some(0),
+            b: Some(Some(1))
+        }
+    );
+}

--- a/tests/pick.rs
+++ b/tests/pick.rs
@@ -12,4 +12,5 @@ fn pick() {
     t.compile_fail("tests/pick/06-empty-fields.rs");
     t.compile_fail("tests/pick/07-field-not-ident.rs");
     t.pass("tests/pick/08-field-not-exist.rs");
+    t.pass("tests/pick/09-forward-attrs.rs");
 }

--- a/tests/pick/09-forward-attrs.rs
+++ b/tests/pick/09-forward-attrs.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Pick;
+
+#[derive(Pick, Debug, PartialEq, Serialize, Deserialize)]
+#[pick(arg(ident = Meta, fields(title, author), derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde)))]
+#[serde(rename_all = "UPPERCASE")]
+struct Article {
+    title: String,
+    author: String,
+    content: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    let meta: Meta = serde_json::from_str(
+        r#"{
+            "TITLE": "Hello, world!",
+            "AUTHOR": "Alice"
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        meta,
+        Meta {
+            title: "Hello, world!".to_string(),
+            author: "Alice".to_string(),
+        }
+    );
+}

--- a/tests/required.rs
+++ b/tests/required.rs
@@ -10,4 +10,5 @@ fn required() {
     t.compile_fail("tests/required/04-no-ident.rs");
     t.pass("tests/required/05-ident-str.rs");
     t.pass("tests/required/06-derive-empty.rs");
+    t.pass("tests/required/07-forward-attrs.rs");
 }

--- a/tests/required/07-forward-attrs.rs
+++ b/tests/required/07-forward-attrs.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use utility_types::Required;
+
+#[derive(Required, Debug, PartialEq, Serialize, Deserialize)]
+#[required(ident = RequiredA, derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde))]
+#[serde(rename_all = "UPPERCASE")]
+pub struct A {
+    a: usize,
+    b: Option<usize>,
+}
+
+fn main() {
+    let a: RequiredA = serde_json::from_str(r#"{"A":0,"B":1}"#).unwrap();
+
+    assert_eq!(a, RequiredA { a: 0, b: 1 });
+}


### PR DESCRIPTION
Previously, only allow, cfg and doc are forwarded. This makes the crate hard to use with crates like serde that need attributes.

This PR adds forward_attrs to all macros and allows users to specify which attributes to forward. An example would be:

```rust
#[derive(Debug, PartialEq, Serialize, Deserialize, Omit)]
#[omit(arg(ident = OmitCD, fields(c, d), derive(Debug, PartialEq, Serialize, Deserialize), forward_attrs(serde)))]
#[serde(rename_all = "UPPERCASE")]
pub struct Foo {
    a: u8,
    b: Option<u8>,
    c: Option<Vec<u8>>,
}

let omit_cd: OmitCD = serde_json::from_str(r#"{"A": 1, "B": 2}"#).unwrap();
assert_eq!(omit_cd, OmitCD { a: 1, b: Some(2) });
```

Mostly fix #9, but several issues are not solved yet:
- users' provided attributes overwrite the default list. Users must manually specify allow, cfg, and doc if forward_attrs is used.
- Which attributes should be in the default list? Maybe all common attributes in Rust should be forwarded?
- Currently, custom attributes for specific generated structs or enums are not implemented. That is, only forwarding is implemented in this PR